### PR TITLE
add-notice-with-url does not work

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
   ],
   "rules": {
     "@typescript-eslint/ban-ts-comment": 0,
-    "@typescript-eslint/no-explicit-any": 0
+    "@typescript-eslint/no-explicit-any": 0,
+    "no-console": 2
   }
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -191,7 +191,6 @@ import { getChangedFiles } from './pullRequest'
     }
 
     if(highestSeverity >= errorOnWarn) {
-      console.log('error-on-warn')
       if(inPr && !failInPr) {
         return
       } else {

--- a/src/statusCheck.ts
+++ b/src/statusCheck.ts
@@ -168,7 +168,10 @@ const closeStatusCheck = async (
     }
   })
 
-  if(input.shouldFail && input.createSummary) {
+  // Do not create a summary
+  if(!input.createSummary) return response.data.id
+
+  if(input.shouldFail) {
     core.error('View for details: ' + response.data.html_url, {
       title: 'Action failed! See link for annotations'
     })


### PR DESCRIPTION
Fixing the add-notice-with-url option to really disable the creation of a notice

**Related Items**

- #98 

**PR closes**

closes #98 
